### PR TITLE
A3F-29 [Backend]: Garantir que não tenha cadastro duplicados de portais.

### DIFF
--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/dao/PortalNoticiaRepository.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/dao/PortalNoticiaRepository.java
@@ -3,6 +3,9 @@ package gsw_api.gsw_api.dao;
 import gsw_api.gsw_api.model.PortalNoticia;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 @Repository
-public interface PortalNoticiaRepository extends JpaRepository<PortalNoticia, Long> {}
+public interface PortalNoticiaRepository extends JpaRepository<PortalNoticia, Long> {
+    Optional<PortalNoticia> findByNomeOrUrl(String nome, String url);
+}

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/service/PortalNoticiaService.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/service/PortalNoticiaService.java
@@ -16,8 +16,17 @@ public class PortalNoticiaService {
     @Autowired
     private PortalNoticiaRepository portalNoticiaRepository;
 
+    private boolean PortaisDuplicados(String nome, String url) {
+        Optional<PortalNoticia> existingPortal = portalNoticiaRepository.findByNomeOrUrl(nome, url);
+        return existingPortal.isPresent();
+    }
+
     @Transactional
     public PortalNoticia create(DadosPortalNoticia dadosPortalNoticia) {
+        if (PortaisDuplicados(dadosPortalNoticia.nome(), dadosPortalNoticia.url())) {
+            throw new IllegalArgumentException("Portal já cadastrado com este nome ou URL.");
+        }
+
         PortalNoticia portalNoticia = new PortalNoticia(
                 dadosPortalNoticia.nome(),
                 dadosPortalNoticia.url(),
@@ -39,6 +48,11 @@ public class PortalNoticiaService {
         Optional<PortalNoticia> optionalPortalNoticia = portalNoticiaRepository.findById(id);
         if (optionalPortalNoticia.isPresent()) {
             PortalNoticia portalNoticia = optionalPortalNoticia.get();
+            
+            if (PortaisDuplicados(dadosPortalNoticia.nome(), dadosPortalNoticia.url())) {
+                throw new IllegalArgumentException("Portal já cadastrado com este nome ou URL.");
+            }
+
             portalNoticia.setNome(dadosPortalNoticia.nome());
             portalNoticia.setUrl(dadosPortalNoticia.url());
             portalNoticia.setParametrizacao(dadosPortalNoticia.parametrizacao());
@@ -52,3 +66,4 @@ public class PortalNoticiaService {
         portalNoticiaRepository.deleteById(id);
     }
 }
+


### PR DESCRIPTION
Descrição da Implementação

- Foi feito a lógica para impedir duplicidade de portais notícias