### PR TITLE
A3F-37 [Backend] API/Servidor: Regionalidade de tags.

### DIFF
--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/config/AppConfig.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/config/AppConfig.java
@@ -1,0 +1,13 @@
+package gsw_api.gsw_api.config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/dao/NoticiaRepository.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/dao/NoticiaRepository.java
@@ -13,5 +13,6 @@ import java.util.List;
 public interface NoticiaRepository extends JpaRepository<Noticia, Long>, JpaSpecificationExecutor<Noticia> {
     List<Noticia> findByTituloContaining(String titulo);
     List<Noticia> findByDataPublicacaoBetween(LocalDate startDate, LocalDate endDate);
+    List<Noticia> findByTags_NomeIn(List<String> nomesTags);
 }
 

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/dao/TagRepository.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/dao/TagRepository.java
@@ -3,7 +3,9 @@ package gsw_api.gsw_api.dao;
 import gsw_api.gsw_api.model.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long>, JpaSpecificationExecutor<Tag> {
     boolean existsByNome(String nome);
+    Optional<Tag> findByNome(String nome);
 }

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/gws.sql
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/gws.sql
@@ -82,3 +82,9 @@ update tb_portal_noticia set parametrizacao =
         "{'URL': 'div.sectionGrid__grid__columnTwo article a','titulo' : 'h1.title','conteudo' : 'p.bullet','autor' : 'a.solar-author-name','data' : 'div.solar-date time'}"
  where id = 1;
 
+ INSERT INTO tb_noticia (titulo, conteudo, dta_publicacao, autor) VALUES
+ ('Mandioca é um alimento versátil', 'A mandioca, também conhecida como aipim, é muito utilizada na culinária brasileira.', '2024-11-01', 'Autor A'),
+ ('Receitas com aipim', 'Aprenda a fazer deliciosas receitas com aipim.', '2024-10-30', 'Autor B'),
+ ('Benefícios da mandioca', 'A mandioca é rica em carboidratos e traz muitos benefícios para a saúde.', '2024-10-29', 'Autor C');
+
+

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/service/SinonimoService.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/service/SinonimoService.java
@@ -1,0 +1,24 @@
+package gsw_api.gsw_api.service;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class SinonimoService {
+
+    private final RestTemplate restTemplate;
+
+    @Autowired
+    public SinonimoService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public List<String> buscarSinonimos(String termo) {
+        String url = "https://api.datamuse.com/synonyms?word=" + termo;
+        String[] sinonimos = restTemplate.getForObject(url, String[].class);
+        return sinonimos != null ? Arrays.asList(sinonimos) : Collections.emptyList();
+    }
+}

--- a/back/gsw-api/src/main/resources/application-dev.properties
+++ b/back/gsw-api/src/main/resources/application-dev.properties
@@ -1,6 +1,7 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/gwsapi
 spring.datasource.username=root
-spring.datasource.password=root
-spring.jpa.hibernate.ddl-auto=none
+spring.datasource.password=1234
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+spring.datasource.initialization-mode=always
 spring.jpa.properties.hibernate.format_sql=truegeneration.scripts.create-target=./gwsapi.sql


### PR DESCRIPTION
Descrição da Implementação

- Desenvolvido um serviço que associe tags a sinônimos regionais, permitindo que ao utilizar um termo específico (ex.: "mandioca"), também sejam sugeridas ou retornadas notícias relacionadas a termos regionais equivalentes (ex.: "aipim") utilizando uma API externa. 
![imagem (1)](https://github.com/user-attachments/assets/76f1a9ae-9324-4a0c-b557-911280da7047)


