### PR TITLE
A3F-37 [Backend] API/Servidor: Regionalidade de tags. 

### DIFF
--- a/Front/gsw-api/src/components/News.vue
+++ b/Front/gsw-api/src/components/News.vue
@@ -18,7 +18,7 @@
         class="mx-2"
         style="flex: 1; min-width: 300px;"
       />
-       <!--<v-select
+      <v-select
         v-model="selectedTags"
         :items="availableTags"
         density="compact"
@@ -32,7 +32,6 @@
         style="flex: 1; min-width: 300px;"
         @change="filterItems"
       />
-      <v-btn @click="searchNews" style="width: 200px; height: 40px" color="primary">Pesquisar</v-btn> -->
     </v-container>
 
     <!-- Lista de notícias -->
@@ -55,7 +54,9 @@
     <v-dialog v-model="NoticiaModal" max-width="800px">
       <v-card>
         <v-card-title>
-          <span class="headline" style="word-wrap: break-word; white-space: normal; overflow-wrap: break-word;">{{ selectedItem?.titulo }}</span>
+          <span class="headline" style="word-wrap: break-word; white-space: normal; overflow-wrap: break-word;">
+            {{ selectedItem?.titulo }}
+          </span>
         </v-card-title>
         <v-card-subtitle>
           Autor: {{ selectedItem?.autor }}
@@ -91,49 +92,81 @@ export default {
     this.fetchTags();
   },
   methods: {
-    async fetchNoticias() {
-      try {
-        const response = await axios.get('http://localhost:8080/noticias/todas');
-        this.items = response.data;
-        this.items.sort((a, b) => new Date(b.dataPublicacao) - new Date(a.dataPublicacao));
-        this.filteredItems = this.items;
-      } catch (error) {
-        console.error('Erro ao buscar notícias:', error);
-      }
-    },
-    async fetchTags() {
-      try {
-        const response = await axios.get('http://localhost:8080/tags');
-        this.availableTags = response.data.map(tag => tag.nome);
-      } catch (error) {
-        console.error('Erro ao buscar tags:', error);
-      }
-    },
-    filterItems() {
-      const searchTerm = this.search.toLowerCase();
-      this.filteredItems = this.items.filter(item =>
-        (item.titulo.toLowerCase().includes(searchTerm) || item.autor.toLowerCase().includes(searchTerm)) &&
-        (this.selectedTags.length === 0 || item.tags.some(tag => this.selectedTags.includes(tag)))
-      );
-    },
-    async searchNews() {
-      try {
-        const response = await axios.get('http://localhost:8080/noticias', {
-          params: {
-            search: this.search,
-            tags: this.selectedTags,
-          },
-        });
-        this.filteredItems = response.data;
-      } catch (error) {
-        console.error('Erro ao buscar notícias:', error);
-      }
-    },
-    openModal(item) {
-      this.selectedItem = item;  // pegando a notícia 
-      this.NoticiaModal = true;    // Abrindo o pop-up
+  async fetchNoticias() {
+    try {
+      const response = await axios.get('http://localhost:8080/noticias/todas');
+      this.items = response.data;
+      this.items.sort((a, b) => new Date(b.dataPublicacao) - new Date(a.dataPublicacao));
+      this.filteredItems = this.items;
+      console.log("Notícias carregadas:", this.items);
+    } catch (error) {
+      console.error('Erro ao buscar notícias:', error);
     }
   },
+  async fetchTags() {
+    try {
+      const response = await axios.get('http://localhost:8080/tags');
+      this.availableTags = response.data.map(tag => tag.nome);
+      console.log("Tags disponíveis carregadas:", this.availableTags);
+    } catch (error) {
+      console.error('Erro ao buscar tags:', error);
+    }
+  },
+  async fetchSynonymsFromDatamuse(tag) {
+    try {
+      const response = await axios.get(`https://api.datamuse.com/words?rel_syn=${tag}`);
+      const synonyms = response.data.map(synonym => synonym.word);
+      console.log(`Sinônimos para a tag "${tag}" obtidos do Datamuse:`, synonyms);
+      return synonyms;
+    } catch (error) {
+      console.error(`Erro ao buscar sinônimos para a tag ${tag} no Datamuse:`, error);
+      return [];
+    }
+  },
+  async filterItems() {
+    const searchTerm = this.search.toLowerCase();
+    console.log("Iniciando filtragem...");
+    console.log("Termo de busca:", searchTerm);
+    console.log("Tags selecionadas:", this.selectedTags);
+
+    let allTags = [...this.selectedTags];
+    for (const tag of this.selectedTags) {
+      const synonyms = await this.fetchSynonymsFromDatamuse(tag);
+      allTags = [...new Set([...allTags, ...synonyms])];
+    }
+    console.log("Tags e sinônimos combinados para filtragem:", allTags);
+
+    this.filteredItems = this.items.filter(item => {
+      const matchesSearch = 
+        item.titulo.toLowerCase().includes(searchTerm) || 
+        item.autor.toLowerCase().includes(searchTerm);
+      console.log(`Notícia "${item.titulo}" - corresponde ao termo de busca:`, matchesSearch);
+
+      const itemTags = Array.isArray(item.tags) ? item.tags : JSON.parse(item.tags || '[]');
+      console.log(`Tags da notícia "${item.titulo}":`, itemTags);
+
+      const matchesTags = 
+        allTags.length === 0 || 
+        (itemTags && itemTags.some(tag => allTags.includes(tag)));
+      console.log(`Notícia "${item.titulo}" - corresponde às tags:`, matchesTags);
+
+      return matchesSearch && matchesTags;
+    });
+
+    console.log("Notícias filtradas:", this.filteredItems);
+  },
+  openModal(item) {
+    this.selectedItem = item;
+    this.NoticiaModal = true;
+    console.log("Notícia selecionada para visualização:", item);
+  }
+ },
+
+  watch: {
+   selectedTags: 'filterItems',
+   search: 'filterItems',
+  }
+
 };
 </script>
 

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/controller/TagController.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/controller/TagController.java
@@ -116,4 +116,9 @@ public class TagController {
 
         return ResponseEntity.ok(dadosTagPage);
     }
+        @GetMapping("/search")
+        public ResponseEntity<List<DadosTag>> searchTags(@RequestParam String termo) {
+            List<DadosTag> tagsRelacionadas = tagService.findTagsByTerm(termo);
+            return ResponseEntity.ok(tagsRelacionadas);
+        }
 }

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/dao/TagRepository.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/dao/TagRepository.java
@@ -3,9 +3,13 @@ package gsw_api.gsw_api.dao;
 import gsw_api.gsw_api.model.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long>, JpaSpecificationExecutor<Tag> {
     boolean existsByNome(String nome);
     Optional<Tag> findByNome(String nome);
+    
+    List<Tag> findByNomeIn(List<String> nomes);
 }

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/dto/SinonimoResponse.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/dto/SinonimoResponse.java
@@ -1,0 +1,15 @@
+package gsw_api.gsw_api.dto;
+
+public class SinonimoResponse {
+    private String word;
+
+    public String getWord() {
+        return word;
+    }
+
+    public void setWord(String word) {
+        this.word = word;
+    }
+}
+
+

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/service/SinonimoService.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/service/SinonimoService.java
@@ -1,10 +1,9 @@
 package gsw_api.gsw_api.service;
 
+import gsw_api.gsw_api.dto.SinonimoResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-
-import gsw_api.gsw_api.dto.SinonimoResponse;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,15 +23,16 @@ public class SinonimoService {
     public List<String> buscarSinonimos(String termo) {
         String url = "https://api.datamuse.com/words?rel_syn=" + termo;
         SinonimoResponse[] resposta = restTemplate.getForObject(url, SinonimoResponse[].class);
-        
-        // Se houver sinônimos, retorna a lista de sinônimos. Se não, retorna o próprio termo ou uma mensagem padrão.
+
         if (resposta != null && resposta.length > 0) {
             return Arrays.stream(resposta)
                          .map(SinonimoResponse::getWord)
                          .collect(Collectors.toList());
         } else {
-            // Caso não haja sinônimos, retornamos o próprio termo ou uma lista vazia
-            return Collections.singletonList(termo);  // ou Collections.emptyList();
+            return Collections.singletonList(termo);
         }
     }
+
+
 }
+

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/service/SinonimoService.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/service/SinonimoService.java
@@ -1,10 +1,15 @@
 package gsw_api.gsw_api.service;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import gsw_api.gsw_api.dto.SinonimoResponse;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class SinonimoService {
@@ -17,8 +22,17 @@ public class SinonimoService {
     }
 
     public List<String> buscarSinonimos(String termo) {
-        String url = "https://api.datamuse.com/synonyms?word=" + termo;
-        String[] sinonimos = restTemplate.getForObject(url, String[].class);
-        return sinonimos != null ? Arrays.asList(sinonimos) : Collections.emptyList();
+        String url = "https://api.datamuse.com/words?rel_syn=" + termo;
+        SinonimoResponse[] resposta = restTemplate.getForObject(url, SinonimoResponse[].class);
+        
+        // Se houver sinônimos, retorna a lista de sinônimos. Se não, retorna o próprio termo ou uma mensagem padrão.
+        if (resposta != null && resposta.length > 0) {
+            return Arrays.stream(resposta)
+                         .map(SinonimoResponse::getWord)
+                         .collect(Collectors.toList());
+        } else {
+            // Caso não haja sinônimos, retornamos o próprio termo ou uma lista vazia
+            return Collections.singletonList(termo);  // ou Collections.emptyList();
+        }
     }
 }

--- a/back/gsw-api/src/main/java/gsw_api/gsw_api/service/TagService.java
+++ b/back/gsw-api/src/main/java/gsw_api/gsw_api/service/TagService.java
@@ -20,6 +20,11 @@ public class TagService {
     @Autowired
     private TagRepository tagRepository;
 
+    @Autowired
+    private SinonimoService sinonimoService;
+
+    
+
     public List<DadosTag> findAll() {
         return tagRepository.findAll().stream()
                 .map(this::convertToDTO)
@@ -73,4 +78,14 @@ public class TagService {
             return predicate;
         };
     }
+
+        // Novo método para buscar tags usando sinônimos
+        public List<DadosTag> findTagsByTerm(String termo) {
+            List<String> sinonimos = sinonimoService.buscarSinonimos(termo);
+            sinonimos.add(termo); // Inclui o termo original
+    
+            return tagRepository.findByNomeIn(sinonimos).stream()
+                    .map(this::convertToDTO)
+                    .collect(Collectors.toList());
+        }
 }

--- a/back/gsw-api/src/main/resources/application-dev.properties
+++ b/back/gsw-api/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/gwsapi
 spring.datasource.username=root
 spring.datasource.password=root
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=truegeneration.scripts.create-target=./gwsapi.sql


### PR DESCRIPTION
Descrição da Implementação

- Implementado serviço de regionalidade no front, agora ao selecionar tags, faz requisição http para pesquisar sinônimos para somar com a tag selecionada, e é adicionada em uma lista virtual, exigindo menos do backend

Sugestão de Melhorias

- Buscar uma API que tenha sinônimos mais gerais do Brasil


![imagem_2024-11-08_172618713](https://github.com/user-attachments/assets/efdfae23-77b0-4c07-9b7c-7a5fbab8532b)
