### PR TITLE
<A3F-57>[Bug]:Tag: Aviso de cadastro.

### DIFF
--- a/Front/gsw-api/src/components/Settings.vue
+++ b/Front/gsw-api/src/components/Settings.vue
@@ -80,6 +80,9 @@ export default {
         { title: 'Nome', value: 'nome' },
         { title: 'Ações', value: 'actions', sortable: false },
       ],
+      snackbar: false,
+      snackbarMessage: '',
+      snackbarColor: '',
     };
   },
 


### PR DESCRIPTION
Descrição da Implementação
 - Foi ajustado bug onde não aparecia o alerta de cadastro de tags.